### PR TITLE
Change MIGS to use SHA256 instead of MD5 [Ready]

### DIFF
--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -1,6 +1,6 @@
 require 'active_merchant/billing/gateways/migs/migs_codes'
 
-require 'digest/md5' # Used in add_secure_hash
+require 'openssl' # Used in add_secure_hash
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -8,6 +8,7 @@ module ActiveMerchant #:nodoc:
       include MigsCodes
 
       API_VERSION = 1
+      HASH_ALGORITHM = 'SHA256'.freeze
 
       class_attribute :server_hosted_url, :merchant_hosted_url
 
@@ -187,7 +188,7 @@ module ActiveMerchant #:nodoc:
 
         response_hash = parse(data)
 
-        expected_secure_hash = calculate_secure_hash(response_hash.reject{|k, v| k == :SecureHash}, @options[:secure_hash])
+        expected_secure_hash = calculate_secure_hash(response_hash, @options[:secure_hash])
         unless response_hash[:SecureHash] == expected_secure_hash
           raise SecurityError, "Secure Hash mismatch, response may be tampered with"
         end
@@ -290,12 +291,15 @@ module ActiveMerchant #:nodoc:
 
       def add_secure_hash(post)
         post[:SecureHash] = calculate_secure_hash(post, @options[:secure_hash])
+        post[:SecureHashType] = HASH_ALGORITHM
       end
 
       def calculate_secure_hash(post, secure_hash)
-        sorted_values = post.sort_by(&:to_s).map(&:last)
-        input = secure_hash + sorted_values.join
-        Digest::MD5.hexdigest(input).upcase
+        input = post.stringify_keys
+                    .select { |k| !%w(SecureHash SecureHashType).include?(k) }
+                    .sort
+                    .map { |(k, v)| "vpc_#{k}=#{v}" }.join('&')
+        OpenSSL::HMAC.hexdigest(HASH_ALGORITHM, [secure_hash].pack('H*'), input).upcase
       end
     end
   end

--- a/test/unit/gateways/migs_test.rb
+++ b/test/unit/gateways/migs_test.rb
@@ -10,32 +10,32 @@ class MigsTest < Test::Unit::TestCase
 
     @credit_card = credit_card
     @amount = 100
-    
-    @options = { 
+
+    @options = {
       :order_id => '1',
       :billing_address => address,
       :description => 'Store Purchase'
     }
   end
-  
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_success response
-    
+
     # Replace with authorization number from the successful response
     assert_equal '123456', response.authorization
   end
 
   def test_unsuccessful_request
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
-    
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of Response, response
     assert_failure response
-    
+
     assert_equal '654321', response.authorization
   end
 
@@ -45,25 +45,29 @@ class MigsTest < Test::Unit::TestCase
       :OrderInfo  => 'A48cvE28',
       :Amount     => 2995
     }
-    ordered_values = "#{@gateway.options[:secure_hash]}2995MER123A48cvE28"
 
+    input = 'vpc_Amount=2995&vpc_MerchantId=MER123&vpc_OrderInfo=A48cvE28'
     @gateway.send(:add_secure_hash, params)
-    assert_equal Digest::MD5.hexdigest(ordered_values).upcase, params[:SecureHash]
+
+    expected_hash = OpenSSL::HMAC.hexdigest('SHA256', [@gateway.options[:secure_hash]].pack('H*'), input).upcase
+
+    assert_equal expected_hash, params[:SecureHash]
+    assert_equal params[:SecureHashType], 'SHA256'
   end
 
   def test_purchase_offsite_response
     # Below response from instance running remote test
-    response_params = "vpc_3DSXID=a1B8UcW%2BKYqkSinLQohGmqQd9uY%3D&vpc_3DSenrolled=U&vpc_AVSResultCode=Unsupported&vpc_AcqAVSRespCode=Unsupported&vpc_AcqCSCRespCode=Unsupported&vpc_AcqResponseCode=00&vpc_Amount=100&vpc_AuthorizeId=367739&vpc_BatchNo=20120421&vpc_CSCResultCode=Unsupported&vpc_Card=MC&vpc_Command=pay&vpc_Locale=en&vpc_MerchTxnRef=9&vpc_Merchant=TESTANZTEST3&vpc_Message=Approved&vpc_OrderInfo=1&vpc_ReceiptNo=120421367739&vpc_SecureHash=8794D9478D030B65F3092282E76283F8&vpc_TransactionNo=2000025183&vpc_TxnResponseCode=0&vpc_VerSecurityLevel=06&vpc_VerStatus=U&vpc_VerType=3DS&vpc_Version=1"
+    response_params = "vpc_3DSXID=a1B8UcW%2BKYqkSinLQohGmqQd9uY%3D&vpc_3DSenrolled=U&vpc_AVSResultCode=Unsupported&vpc_AcqAVSRespCode=Unsupported&vpc_AcqCSCRespCode=Unsupported&vpc_AcqResponseCode=00&vpc_Amount=100&vpc_AuthorizeId=367739&vpc_BatchNo=20120421&vpc_CSCResultCode=Unsupported&vpc_Card=MC&vpc_Command=pay&vpc_Locale=en&vpc_MerchTxnRef=9&vpc_Merchant=TESTANZTEST3&vpc_Message=Approved&vpc_OrderInfo=1&vpc_ReceiptNo=120421367739&vpc_SecureHash=20DE2CDEBE40D6F24E3ABC5D74081CB5B341CD447530121AD51A9504A923BBD0&vpc_TransactionNo=2000025183&vpc_TxnResponseCode=0&vpc_VerSecurityLevel=06&vpc_VerStatus=U&vpc_VerType=3DS&vpc_Version=1"
 
     response_hash = @gateway.send(:parse, response_params)
     response_hash.delete(:SecureHash)
     calculated_hash = @gateway.send(:calculate_secure_hash, response_hash, @gateway.options[:secure_hash])
-    assert_equal '8794D9478D030B65F3092282E76283F8', calculated_hash
+    assert_equal '20DE2CDEBE40D6F24E3ABC5D74081CB5B341CD447530121AD51A9504A923BBD0', calculated_hash
 
     response = @gateway.purchase_offsite_response(response_params)
     assert_success response
 
-    tampered_response1 = response_params.gsub('83F8', '93F8')
+    tampered_response1 = response_params.gsub('20DE', '93F8')
     assert_raise(SecurityError){@gateway.purchase_offsite_response(tampered_response1)}
 
     tampered_response2 = response_params.gsub('Locale=en', 'Locale=es')
@@ -71,7 +75,7 @@ class MigsTest < Test::Unit::TestCase
   end
 
   private
-  
+
   # Place raw successful response from gateway here
   def successful_purchase_response
     build_response(
@@ -79,7 +83,7 @@ class MigsTest < Test::Unit::TestCase
       :TransactionNo   => '123456'
     )
   end
-  
+
   # Place raw failed response from gateway here
   def failed_purchase_response
     build_response(
@@ -87,7 +91,7 @@ class MigsTest < Test::Unit::TestCase
       :TransactionNo   => '654321'
     )
   end
-  
+
   def build_response(options)
     options.collect { |key, value| "vpc_#{key}=#{CGI.escape(value.to_s)}"}.join('&')
   end


### PR DESCRIPTION
This change relates to a PCI compliance issue for American School of Bombay

https://clients.veracross.com/asb/requests/63651

There is an open issue with this same patch in the main active_merchant repo here:

https://github.com/activemerchant/active_merchant/pull/2257

