### PR TITLE
Fixing duplicate error code.

### DIFF
--- a/lib/active_merchant/billing/gateways/gmo.rb
+++ b/lib/active_merchant/billing/gateways/gmo.rb
@@ -307,7 +307,7 @@ module ActiveMerchant #:nodoc:
         '42G300000' => 'Card is not valid for transactions',
         '42G420000' => 'PIN is incorrect',
         '42G440000' => 'Security code is incorrect',
-        '42G030000' => 'Security code not provided',
+        '42G530000' => 'Security code not provided',
         '42G540000' => 'Card is not valid for transactions',
         '42G550000' => 'Card limit has been exceeded',
         '42G560000' => 'Card is not valid for transactions',
@@ -784,4 +784,3 @@ module ActiveMerchant #:nodoc:
     end
   end
 end
-


### PR DESCRIPTION
Fixes error:

/lib/active_merchant/billing/gateways/gmo.rb:302: warning: key "42G030000" is duplicated and overwritten on line 310
