### PR TITLE
Reducing truncation of meta-value to 50 per bluesnap requirements

### DIFF
--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -221,7 +221,7 @@ module ActiveMerchant
         doc.send("transaction-meta-data") do
           doc.send("meta-data") do
             doc.send("meta-key", "description")
-            doc.send("meta-value", truncate(description, 500))
+            doc.send("meta-value", truncate(description, 50))
             doc.send("meta-description", "Description")
           end
         end


### PR DESCRIPTION
Bluesnap has a max limit set on metadata values.

Changing from 500 to 50.