### PR TITLE
Update refund to support newer BlueSnap api methodology.

### DIFF
--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -68,9 +68,9 @@ class BlueSnapTest < Test::Unit::TestCase
   def test_successful_refund
     @gateway.expects(:raw_ssl_request).returns(successful_refund_response)
 
-    response = @gateway.refund(@amount, "Authorization")
+    response = @gateway.refund(@amount, "1012082839")
     assert_success response
-    assert_equal "1012082907", response.authorization
+    assert_equal 204, response.params["code"].to_i
   end
 
   def test_failed_refund
@@ -346,37 +346,7 @@ class BlueSnapTest < Test::Unit::TestCase
   end
 
   def successful_refund_response
-    MockResponse.succeeded <<-XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <card-transaction xmlns="http://ws.plimus.com">
-         <card-transaction-type>REFUND</card-transaction-type>
-         <transaction-id>1012082907</transaction-id>
-         <recurring-transaction>ECOMMERCE</recurring-transaction>
-         <soft-descriptor>BLS*Spreedly</soft-descriptor>
-         <amount>1.00</amount>
-         <currency>USD</currency>
-         <card-holder-info>
-            <first-name>Longbob</first-name>
-            <last-name>Longsen</last-name>
-            <country>ca</country>
-            <state>ON</state>
-            <city>Ottawa</city>
-            <zip>K1C2N6</zip>
-         </card-holder-info>
-         <credit-card>
-            <card-last-four-digits>9299</card-last-four-digits>
-            <card-type>VISA</card-type>
-            <card-sub-type>CREDIT</card-sub-type>
-         </credit-card>
-         <processing-info>
-            <processing-status>SUCCESS</processing-status>
-            <cvv-response-code>ND</cvv-response-code>
-            <avs-response-code-zip>U</avs-response-code-zip>
-            <avs-response-code-address>U</avs-response-code-address>
-            <avs-response-code-name>U</avs-response-code-name>
-         </processing-info>
-      </card-transaction>
-    XML
+    MockResponse.new(204, 'OK', '')
   end
 
   def failed_refund_response


### PR DESCRIPTION
This commit adds support for refunds using the current version of the BlueSnap payments api.

Primary changes:

- [x] use a modified end point url for refund transactions. 
e.g. `https://sandbox.bluesnap.com/services/2/transactions/:transaction-id/refund`
- [x] no longer send an XML document with refund requests
- [x] no XML handling is required on the response. Only a response code of 204 with no content is returned upon success.