### PR TITLE
Adding first_name and last_name to customer when submitting Braintree

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -536,8 +536,8 @@ module ActiveMerchant #:nodoc:
             :email => scrub_email(options[:email]),
             :phone => options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
               options[:billing_address][:phone]),
-            :first_name => options[:billing_address][:name].split(' ')[0], # getting first name
-            :last_name => options[:billing_address][:name][options[:billing_address][:name].split(' ')[0].length + 1...options[:billing_address][:name].length] # getting all names after first
+            :first_name => options[:billing_address][:name].split(/\s+/, 2)[0], # getting first name
+            :last_name => options[:billing_address][:name].split(/\s+/, 2)[1] # getting all names after first
           },
           :options => {
             :store_in_vault => options[:store] ? true : false,

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -533,7 +533,11 @@ module ActiveMerchant #:nodoc:
           :order_id => options[:order_id],
           :customer => {
             :id => options[:store] == true ? "" : options[:store],
-            :email => scrub_email(options[:email])
+            :email => scrub_email(options[:email]),
+            :phone => options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
+              options[:billing_address][:phone]),
+            :first_name => options[:billing_address][:name].split(' ')[0], # getting first name
+            :last_name => options[:billing_address][:name][options[:billing_address][:name].split(' ')[0].length + 1...options[:billing_address][:name].length] # getting all names after first
           },
           :options => {
             :store_in_vault => options[:store] ? true : false,

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -534,8 +534,7 @@ module ActiveMerchant #:nodoc:
           :customer => {
             :id => options[:store] == true ? "" : options[:store],
             :email => scrub_email(options[:email]),
-            :phone => options[:phone] || (options[:billing_address][:phone] if options[:billing_address] &&
-              options[:billing_address][:phone]),
+            :phone => options[:phone] || options.dig(:billing_address, :phone),
             :first_name => options[:billing_address][:name].split(/\s+/, 2)[0], # getting first name
             :last_name => options[:billing_address][:name].split(/\s+/, 2)[1] # getting all names after first
           },

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -535,8 +535,8 @@ module ActiveMerchant #:nodoc:
             :id => options[:store] == true ? "" : options[:store],
             :email => scrub_email(options[:email]),
             :phone => options[:phone] || options.dig(:billing_address, :phone),
-            :first_name => options[:billing_address][:name].split(/\s+/, 2)[0], # getting first name
-            :last_name => options[:billing_address][:name].split(/\s+/, 2)[1] # getting all names after first
+            :first_name => options[:billing_address][:name].reverse.split(/\s+/, 2).last.reverse, # getting name minus last name (because of reverse the last item is the first name)
+            :last_name => options[:billing_address][:name].reverse.split(/\s+/, 2).first.reverse # getting last name (because of reverse the first item is the last name)
           },
           :options => {
             :store_in_vault => options[:store] ? true : false,


### PR DESCRIPTION
The name of the customer stopped showing up when we switched a client to Payments V3. The customer's name wasn't being included when using the nonce. 

Related to https://clients.veracross.com/browning/requests/104892