### PR TITLE
Adding the Braintree transaction_id to response.params

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -344,6 +344,7 @@ module ActiveMerchant #:nodoc:
       def response_params(result)
         params = {}
         params[:customer_vault_id] = result.transaction.customer_details.id if result.success?
+        params[:transactionid] = result.transaction.id if result.success?
         params[:braintree_transaction] = transaction_hash(result)
         params
       end


### PR DESCRIPTION
Adding the `transaction_id` to the `response.params` for Braintree transactions